### PR TITLE
Fixes `texture` example `cube.arm` path.

### DIFF
--- a/texture/Sources/Main.hx
+++ b/texture/Sources/Main.hx
@@ -104,7 +104,7 @@ class Main {
 		var o:TObj = {
 			name: "Cube",
 			type: "mesh_object",
-			data_ref: "Cube.arm/Cube",
+			data_ref: "cube.arm/Cube",
 			material_refs: ["MyMaterial"],
 			transform: null
 		};


### PR DESCRIPTION
Filesystems are case-sensitive in Linux.